### PR TITLE
EE-12142: ovveride default nginx proxy timeouts

### DIFF
--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -110,6 +110,9 @@ spec:
               value: /certs/tls.pem
             - name: SERVER_KEY
               value: /certs/tls-key.pem
+            - name: ADD_NGINX_LOCATION_CFG
+              value: 'proxy_read_timeout 99999s;
+                      proxy_connect_timeout 60s;'
             - name: ADD_NGINX_SERVER_CFG
               value: 'gzip off; location = /reload { allow 127.0.0.1; deny all; content_by_lua_block { os.execute("touch /tmp/nginx-reload-triggered; /usr/local/openresty/nginx/sbin/nginx -s reload; touch /tmp/nginx-reload-complete;") } }'
           volumeMounts:

--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -111,8 +111,7 @@ spec:
             - name: SERVER_KEY
               value: /certs/tls-key.pem
             - name: ADD_NGINX_LOCATION_CFG
-              value: 'proxy_read_timeout 99999s;
-                      proxy_connect_timeout 60s;'
+              value: 'proxy_read_timeout 99999s; proxy_connect_timeout 60s;'
             - name: ADD_NGINX_SERVER_CFG
               value: 'gzip off; location = /reload { allow 127.0.0.1; deny all; content_by_lua_block { os.execute("touch /tmp/nginx-reload-triggered; /usr/local/openresty/nginx/sbin/nginx -s reload; touch /tmp/nginx-reload-complete;") } }'
           volumeMounts:


### PR DESCRIPTION
This so that IPS has time to complete a request and return the correct response in the UI.